### PR TITLE
Add support for single files without handler arg and fix unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ WORKDIR ${WORKDIR}
 COPY function-server /function-server/
 RUN cd /function-server; npm install --production
 
-CMD ["node", "/function-server/server.js"]
+CMD node /function-server/server.js $(cat /tmp/handler)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nodejs-base-image
 JavaScript (Node.js) support for Dispatch
 
-Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/nodejs-base/): `dispatchframework/nodejs-base:0.0.6`
+Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/nodejs-base/): `dispatchframework/nodejs-base:0.0.7`
 
 ## Usage
 
@@ -11,7 +11,7 @@ You need a recent version of Dispatch [installed in your Kubernetes cluster, Dis
 
 To add the base-image to Dispatch:
 ```bash
-$ dispatch create base-image nodejs-base dispatchframework/nodejs-base:0.0.6
+$ dispatch create base-image nodejs-base dispatchframework/nodejs-base:0.0.7
 ```
 
 Make sure the base-image status is `READY` (it normally goes from `INITIALIZED` to `READY`):

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e -x
 
 cd $(dirname $0)
 
-docker build -t dispatchframework/nodejs-base:0.0.6 .
+docker build -t dispatchframework/nodejs-base:0.0.7 .

--- a/function-server/server.js
+++ b/function-server/server.js
@@ -45,7 +45,7 @@ function wrap(f) {
     }
 }
 
-const fun = wrap(require(`${process.cwd()}/${HANDLER}`));
+const fun = wrap(require(`${process.cwd()}/${process.argv[2]}`));
 const createApp = require('./http-api');
 
 const app = createApp(fun);

--- a/function-server/spec/function-server/http-api-spec.js
+++ b/function-server/spec/function-server/http-api-spec.js
@@ -7,7 +7,7 @@
 
 describe("http-api tests", function() {
     // server depends on these environmental variables
-    process.env.FUNCTION_MODULE = "../function";
+    process.argv[2] = "../function.js";
     process.env.PORT = 8080;
 
     const server = require('../../server');

--- a/function-server/spec/function-server/server-spec.js
+++ b/function-server/spec/function-server/server-spec.js
@@ -7,7 +7,7 @@
 
 describe("server tests", function() {
     // server depends on these environmental variables
-    process.env.FUNCTION_MODULE = "../function";
+    process.argv[2] = "../function.js";
     process.env.PORT = 8080;
 
     const server = require('../../server');

--- a/function-template/Dockerfile
+++ b/function-template/Dockerfile
@@ -8,4 +8,8 @@ ENV HANDLER=${HANDLER}
 
 COPY . .
 
-CMD ["node", "/function-server/server.js"]
+# Create handler file if passed in otherwise assume default handler
+RUN echo -n ${HANDLER} > /tmp/handler
+RUN [ -z "${HANDLER}" ] && \
+    [ $(ls *.js | wc -l) -eq "1" ] && \
+    ls *.js > /tmp/handler || :


### PR DESCRIPTION
* Fix unit tests when importing handler
* Can create functions with single file without specifying the `--handler` argument