### PR TITLE
[function/timeout] Blocking function timeout for nodejs

### DIFF
--- a/function-server/http-api.js
+++ b/function-server/http-api.js
@@ -14,6 +14,9 @@ module.exports = (fun) => {
     const app = express();
 
     app.get('/healthz', (req, res) => {
+        if (!HEALTHY) {
+            res.statusCode = 500
+        }
         res.json({});
     });
 


### PR DESCRIPTION
This adds function timeouts for node functions. This implementation does not defend against user functions blocking the event loop. In the case of the event loop blocking indefinitely, new invocations will receive no response, and the healthz endpoint will not respond either. 